### PR TITLE
Bind handlers' this for sender information

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ function message200Handler(data, callback) {
 }
 ```
 
+## How To Get A Sender Information
+
+```javascript
+const mlink = require('mesh-link');
+var handlerId = 3000;
+mlink.handler(handlerId, message3000Handler);
+
+function message3000Handler() {
+    // You can get sender information using this.sender
+    console.log('Message from: ' + this.sender.address + ':' + this.sender.port);
+}
+```
+
 # Shared Objects
 
 A shared object is an object that can be shared and mutated from all mesh nodes asynchronously, and the object remains synchronized across all mesh nodes.

--- a/lib/delivery.js
+++ b/lib/delivery.js
@@ -124,7 +124,8 @@ function localSend(handlerId, wrappedData, responseCallback) {
         responseCallback(new Error('Local command response timed out - handler ID:' + handlerId));
     }, CLEAN_INTERVAL);
     _onHandleCallback(wrappedData);
-    handlers[handlerId](wrappedData.data, (res) => {
+    const receiver = _createReceiver(true, reliable.info());
+    handlers[handlerId].call(receiver, wrappedData.data, (res) => {
         clearTimeout(timeout);
         if (res instanceof Error) {
             responseCallback(res);
@@ -247,7 +248,8 @@ function _onMsg(buf, sender) {
                 '<delivery>Message received - handler ID:', handlerId,
                 'data:', data, 'response', (resp ? true : false)
             );
-            handlers[handlerId](data, resp);
+            const receiver = _createReceiver(false, sender);
+            handlers[handlerId].call(receiver, data, resp);
         break;
         case RESP_TYPE:
             // received a response;
@@ -346,7 +348,13 @@ function _onUmsg(buf, sender) {
         resp = _response.bind(null, { ridbuf: ridbuf, handlerId: handlerId, sender: sender });
     }
     logger.sys('<delivery>Unreliable message received - handler ID:', handlerId, 'data:', data);
-    handlers[handlerId](data, resp);
+    const receiver = _createReceiver(false, sender);
+    handlers[handlerId].call(receiver, data, resp);
+}
+
+function _createReceiver(isLocal, sender) {
+    const senderInfo = Object.assign({isLocal: isLocal}, sender);
+    return {sender: senderInfo};
 }
 
 function _onAck(msgId) {

--- a/test/index.js
+++ b/test/index.js
@@ -215,6 +215,28 @@ describe('mesh-link', () => {
         }, bindDone(done));
     });
 
+    it('Node "one" handler can get sender info from node "three" client', (done) => {
+        runClient('getSender', PORT_THREE, (buf, next) => {
+            var res = JSON.parse(buf);
+            eq(res.address, ADDR, () => {
+                eq(res.port, 4002, () => {
+                    eq(res.isLocal, false, next);
+                });
+            });
+        }, bindDone(done));
+    });
+
+    it('Node "one" handler can get sender info from node "one" client', (done) => {
+        runClient('getSender', PORT_ONE, (buf, next) => {
+            var res = JSON.parse(buf);
+            eq(res.address, ADDR, () => {
+                eq(res.port, 4000, () => {
+                    eq(res.isLocal, true, next);
+                });
+            });
+        }, bindDone(done));
+    });
+
     it('Node "one" can save data on its backup nodes', (done) => {
         startTimer();
         runClient('saveOnBackupNodes', PORT_TWO, (buf, next) => {

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -150,6 +150,11 @@ function onListening() {
         console.log('----> Get from backup', thingToSave, mlink.info());
         cb({ thing: thingToSave, info: mlink.info() });
     });
+    // getSender
+    mlink.handler(12, function (nothing, cb) {
+        console.log(JSON.stringify(this));
+        cb(this.sender);
+    });
     mlink.onNewNodes((nodes) => {
         console.log('New mesh nodes detected:', nodes);
     });
@@ -447,6 +452,19 @@ function onMessage(buf, remote) {
                 server.send(buf, 0, buf.length, remote.port, remote.address);
             });
         break;
+        case 'getSender':
+            var node = getNodeByName('one');
+            mlink.send(12, [node], {}, (error, res) => {
+                if (error) {
+                    console.error('getSender receive error', error.message);
+                    var err = Buffer.from(error.message);
+                    server.send(err, 0, err.length, remote.port, remote.address);
+                    return;
+                }
+                var buf = Buffer.from(JSON.stringify(res));
+                server.send(buf, 0, buf.length, remote.port, remote.address);
+            });
+            break;
     }
 }
 


### PR DESCRIPTION
Message handlers cannot retrieve the sender's information currently.
I think that the availability of the sender's information (address, port) improves flexibility for handlers.

By this pull request, handlers can retrieve sender information using `this.sender`.